### PR TITLE
Fix compatibility issues in compile.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 Debug/
 Release/
 build/
+cmake-build*/
 out/
 
 # Compiled source #

--- a/compile.sh
+++ b/compile.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ###############################################################
 # File:          compile.sh
 # Creation Date: 10/11/2022 (DD/MM/YYYY)
@@ -9,26 +9,33 @@
 # Copyright:     LNH team (c) 2022, all rights reserved
 ################################################################
 
+set -euo pipefail
 
+# change directory to the one containing the source code project
+cd "$(dirname "$(realpath "$0")")"
+
+# check available CMake version
 echo "[>] Configuring project with CMake.."
 
 # Clean previous build/ folders if they exist
-rm -rf build/
-mkdir build
-
-# Export the SDK Path before running CMAKE
-export PICO_SDK_PATH=../pico-sdk
+rm -rf build/ || true
+mkdir -p build
 
 # Specify CMAKE where we want the build tree to be at.
 # In our case, the build/ directory.
 # The source directory will be . (the current directory,
 # where the CMakeLists.txt is located).
-cmake -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo -B build/ .
+PICO_SDK_PATH=../pico-sdk \
+CMAKE_POLICY_VERSION_MINIMUM=3.5 \
+	cmake -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
+		-B build/ .
 
 echo "[>] Building FIRMWARE: "
 
 # Go and build the firmware
-cd build
-make
+PICO_SDK_PATH=../pico-sdk \
+CMAKE_POLICY_VERSION_MINIMUM=3.5 \
+CMAKE_BUILD_PARALLEL_LEVEL="$(nproc)" \
+	cmake --build build
 
 echo "[>] Build completed. Find the DSpico.uf2 file inside build/ folder"

--- a/compile.sh
+++ b/compile.sh
@@ -11,6 +11,14 @@
 
 set -euo pipefail
 
+if command -v nproc >/dev/null 2>&1; then
+	NPROC="$(nproc)"
+else
+	# macOS doesn't have nproc(1). using getconf here is also more general than
+	# using sysctl
+	NPROC="$(getconf _NPROCESSORS_ONLN)"
+fi
+
 # change directory to the one containing the source code project
 cd "$(dirname "$(realpath "$0")")"
 
@@ -35,7 +43,7 @@ echo "[>] Building FIRMWARE: "
 # Go and build the firmware
 PICO_SDK_PATH=../pico-sdk \
 CMAKE_POLICY_VERSION_MINIMUM=3.5 \
-CMAKE_BUILD_PARALLEL_LEVEL="$(nproc)" \
+CMAKE_BUILD_PARALLEL_LEVEL="${NPROC}" \
 	cmake --build build
 
 echo "[>] Build completed. Find the DSpico.uf2 file inside build/ folder"


### PR DESCRIPTION
* Use `/usr/bin/env bash`, because not all distros put bash in `/bin` (some in `/usr/bin`), and with NixOS it's even more complicated. This should make it compatible across all distros.
* The `set -euo pipefail` makes the script exit immediately on error, otherwise it tries to continue e.g. running make when the CMake configuration failed.
* Change to the directory the script sits in, in case it is ever called from another directory.
* With CMake 4.x, declaring compatibility with version 3.5 straight up errors. Passing the extra argument and modifying the pioasm CMakeLists.txt fixes this issue. See https://gitlab.kitware.com/cmake/cmake/-/issues/26613 and https://gitlab.kitware.com/cmake/cmake/-/issues/26698 for more info.
* CMake doesn't always emit Makefiles by default, so that needs to be passed in using the -G option.
* Compile using all available cores, instead of only using a single CPU core.
* `compile.sh` is now also executable in its filesystem permission bits.

Currently, I'm using a Python script to check the available CMake version, as it can do proper parsing and version comparison. If desired, I can replace it with basic string regex matching.