### PR TITLE
Return SD Sector Count with 0xE2 Command.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -132,10 +132,15 @@ static void initSd(void)
     bool ok = false;
     for (int i = 0; i < 16; i++)
     {
-        if (f_mount(&sFatFs, "0:", 1) == FR_OK)
+        FRESULT sd_mount = f_mount(&sFatFs, "0:", 1);
+        if (sd_mount == FR_OK)
         {
             ok = true;
             sIsSdCardMounted = true;
+            break;
+        }
+        else if (sd_mount == FR_NO_FILESYSTEM)
+        {
             break;
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -132,14 +132,14 @@ static void initSd(void)
     bool ok = false;
     for (int i = 0; i < 16; i++)
     {
-        FRESULT sd_mount = f_mount(&sFatFs, "0:", 1);
-        if (sd_mount == FR_OK)
+        FRESULT mountResult = f_mount(&sFatFs, "0:", 1);
+        if (mountResult == FR_OK)
         {
             ok = true;
             sIsSdCardMounted = true;
             break;
         }
-        else if (sd_mount == FR_NO_FILESYSTEM)
+        else if (mountResult == FR_NO_FILESYSTEM)
         {
             break;
         }

--- a/src/ntrCardIrq.S
+++ b/src/ntrCardIrq.S
@@ -190,7 +190,7 @@ gGameNoScrambleCmd0HandlerTable:
 .endr
     .word ntrc_gameNoScrambleCmd0Dummy //E0
     .word ntrc_gameNoScrambleCmd0Dummy //E1
-    .word ntrc_gameNoScrambleCmd0Dummy //E2
+    .word ntrc_gameGetSdSectCntCmd0 //E2
     .word ntrc_gameNoScrambleCmd0Dummy //E3
     .word ntrc_gameGetSdStatCmd0 //E4
     .word ntrc_gameGetSdDataCmd0 //E5
@@ -305,7 +305,7 @@ gGameNoScrambleCmd1HandlerTable:
 .endr
     .word ntrc_gameNoScrambleCmd1Unknown //E0
     .word ntrc_gameNoScrambleCmd1Unknown //E1
-    .word ntrc_gameNoScrambleCmd1Unknown //E2
+    .word ntrc_gameNoScrambleCmd1Dummy4 //E2
     .word ntrc_gameReqSdReadCmd1 //E3
     .word ntrc_gameNoScrambleCmd1Dummy4 //E4
     .word ntrc_gameGetSdDataCmd1 //E5

--- a/src/ntrCardRomGameSd.cpp
+++ b/src/ntrCardRomGameSd.cpp
@@ -81,6 +81,13 @@ extern "C" void __scratch_y("cpu0") ntrc_gameGetSdStatCmd0(ntr_rom_emu_t* romEmu
     }
 }
 
+extern "C" void __scratch_y("cpu0") ntrc_gameGetSdSectCntCmd0(ntr_rom_emu_t* romEmu, u32 word, pio_hw_t* pio)
+{
+    ntrc_beginWrite(pio, 4);
+    ntrc_writeWord(pio, gSdCard.GetNumSectors());
+    ntrc_finishGameNoScrambleCmd0(romEmu);
+}
+
 extern "C" void __scratch_y("cpu0") ntrc_gameGetSdDataCmd0(ntr_rom_emu_t* romEmu, u32 word, pio_hw_t* pio)
 {
     ntrc_beginWrite(pio, 512);

--- a/src/sd/SdCard.h
+++ b/src/sd/SdCard.h
@@ -79,6 +79,10 @@ public:
     /// @return The number of sectors that have been completed in the current read or write.
     u32 GetSectorsCompleted() const { return _sectorsCompleted; }
 
+    /// @brief Returns the number of sectors, if the _state is not idle the function will return 0. 
+    /// @return The number of sectors, each sector is 0x200 bytes. 
+    u32 GetNumSectors() const { return _state != State::Idle ? 0 : (_lastSdSector + 1); }
+
     /// @brief Reads the given number of sectors from the given \p sector to the \p dst buffer.
     ///        This function blocks until the read is complete.
     /// @param dst The destination buffer.


### PR DESCRIPTION
Sector count from 0xE2 enables tools to compute SD size for reliable complete image dumps and restores.