### PR TITLE
Fix SD hangs on certain write sequences

### DIFF
--- a/src/sd/rp2040_sdio.cpp
+++ b/src/sd/rp2040_sdio.cpp
@@ -662,6 +662,7 @@ static void rp2040_sdio_irq()
                 channel_config_set_dreq(&dmacfg, pio_get_dreq(SDIO_PIO, SDIO_DATA_SM, false));
                 dma_channel_configure(SDIO_DMA_CHB, &dmacfg,
                     &g_sdio.card_response, &SDIO_PIO->rxf[SDIO_DATA_SM], 1, true);
+                return;
             }
         }
     }


### PR DESCRIPTION
When the card status is not ready yet (after a successful write tx is completed) a second DMA is scheduled to read the return code (instead of manually reading it when it's ready). The current code schedules the DMA and immediately proceeds to complete the read due to a missing early return. This results in the IRQ handler being called one extra time and desyncing the TX sequence, which hangs due to "done" > "total"

It is unclear when this happens, allegedly when the DMA IRQ is triggered before the card becomes Idle (response is pushed after it becomes Idle).