### PR TITLE
fix compilation with pico sdk 2.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ pico_sdk_init()
 add_compile_definitions(DSpico
   PICO_STACK_SIZE=0x600
   PICO_CORE1_STACK_SIZE=0x400
+  PICO_CRT0_ALLOCATE_SPACERS=0 #flag required when building using pico sdk 1.5.1 and later
   ENABLE_R4_MODE
   #DSPICO_ENABLE_WRFUXXED # This macro enables the WRFUXXED exploit to work.
   # ENABLE_PREVENT_DSI_AUTOBOOT # meant to be used with WRFU, doesn't work properly on the 3ds

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ pico_sdk_init()
 add_compile_definitions(DSpico
   PICO_STACK_SIZE=0x600
   PICO_CORE1_STACK_SIZE=0x400
-  PICO_CRT0_ALLOCATE_SPACERS=0 #flag required when building using pico sdk 1.5.1 and later
+  PICO_CRT0_ALLOCATE_SPACERS=0 #flag required when building using pico sdk 2.0.0 and later
   ENABLE_R4_MODE
   #DSPICO_ENABLE_WRFUXXED # This macro enables the WRFUXXED exploit to work.
   # ENABLE_PREVENT_DSI_AUTOBOOT # meant to be used with WRFU, doesn't work properly on the 3ds

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include "common.h"
 #include <string.h>
 #include <stdio.h>
+#include "hardware/clocks.h"
 #include "hardware/gpio.h"
 #include "hardware/dma.h"
 #include "hardware/structs/scb.h"


### PR DESCRIPTION
Update sources and cmake file to be compatible with the pico sdk 2.2.0.
The flag PICO_CRT0_ALLOCATE_SPACERS=0 is needed to make the project link properly https://github.com/raspberrypi/pico-sdk/blob/master/src/rp2_common/pico_crt0/crt0.S#L575C37-L586C96 due to a changed behaviour in 1.5.1.
The firmware built against the currently targeted sdk (1.5.0) is binary identical with these changes, so there's no harm in including them already for futureproofing