### PR TITLE
Optional board status LEDs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,11 +10,14 @@ add_compile_definitions(DSpico
   PICO_CORE1_STACK_SIZE=0x400
   ENABLE_R4_MODE
   #DSPICO_ENABLE_WRFUXXED # This macro enables the WRFUXXED exploit to work.
+  #ENABLE_STATUS_LEDS # This macro drives the two board status LEDs: blue for SD activity, red when an SD transfer cannot be started.
   # ENABLE_PREVENT_DSI_AUTOBOOT # meant to be used with WRFU, doesn't work properly on the 3ds
 )
 
 add_executable(DSpico
   src/main.cpp
+  src/led.cpp
+  src/led.h
   src/common.h
   src/romData.S
   src/romData.h

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The `CMakeList.txt` file contains a couple of options that you can configure.
    * `ENABLE_R4_MODE` - Enables R4 emulation. This allows you to use R4 software, such as the Wood R4 kernel. As R4 emulation can be used together with regular DSpico software, it can usually be kept enabled.
       * Note that to be able to use R4 software, your SD card must be at most 4 GB, or have a single partition in the first 4 GB of the SD card. R4 card commands cannot address SD sectors above 4 GB!
    * `DSPICO_ENABLE_WRFUXXED` - Enables emulation of the IS-SPI-USB-ADAPTER to support the WRFUxxed exploit. This requires <code>uartBufv060.bin</code> to be placed in the `data/` folder.
+   * `ENABLE_STATUS_LEDS` - Drives the two board status LEDs, which are otherwise left dark: blue blinks on SD card activity, and red latches on when the firmware cannot start an SD transfer it needs. It is off by default because lighting them draws from the DS battery.
    * `ENABLE_PREVENT_DSI_AUTOBOOT` - Experimental feature that prevents DSi consoles from autobooting when the autoboot flag is set. It was intended to be used with WRFU Tester, which has the autoboot flag set. It is generally not recommended to use this, as it does not work properly with the 3DS and has not been tested much.
 
 ### Setting up the rom(s)

--- a/src/common.h
+++ b/src/common.h
@@ -52,6 +52,10 @@ typedef volatile int64_t vs64;
 
 #define PIN_USB_VBUS    24
 
+// Board status LEDs, both active high. See the pinout in the dspico-hardware repo.
+#define PIN_LED_R       27
+#define PIN_LED_B       28
+
 #define PIN_DEV_TX0     0
 #define PIN_DEV_RX0     1
 #define DEV_UART_PIN_MASK  ((1u << PIN_DEV_RX0) | (1u << PIN_DEV_TX0))

--- a/src/led.cpp
+++ b/src/led.cpp
@@ -1,0 +1,98 @@
+#ifdef ENABLE_STATUS_LEDS
+
+#include "common.h"
+#include "led.h"
+#include "hardware/gpio.h"
+
+// Power saving gates the timer clock, so the holds below count main loop passes
+// rather than milliseconds. A write is held far longer than a read, and that
+// difference is what makes a save stand out from a game streaming its rom.
+#define LED_WRITE_HOLD_PASSES   20000u
+#define LED_READ_HOLD_PASSES    2000u
+
+// Reads light the LED on one pass in 2^N. At full duty a running game keeps it
+// solid and it stops carrying any information. Writes stay at full duty.
+#define LED_READ_DUTY_SHIFT     3u
+
+// Not static, so the notify helpers in led.h can stay inline at the call sites.
+volatile uint32_t gLedSdReadEvents = 0;
+volatile uint32_t gLedSdWriteEvents = 0;
+
+static u32 sSeenReadEvents = 0;
+static u32 sSeenWriteEvents = 0;
+static u32 sReadHold = 0;
+static u32 sWriteHold = 0;
+static u32 sPass = 0;
+static bool sFaulted = false;
+
+void ledInit(void)
+{
+    // Level before direction, so the pin cannot glitch a flash of light at boot.
+    // 2 mA matches the drive strength the other outputs here use.
+    gpio_set_drive_strength(PIN_LED_R, GPIO_DRIVE_STRENGTH_2MA);
+    gpio_set_drive_strength(PIN_LED_B, GPIO_DRIVE_STRENGTH_2MA);
+    gpio_disable_pulls(PIN_LED_R);
+    gpio_disable_pulls(PIN_LED_B);
+    gpio_put(PIN_LED_R, false);
+    gpio_put(PIN_LED_B, false);
+    gpio_set_dir(PIN_LED_R, GPIO_OUT);
+    gpio_set_dir(PIN_LED_B, GPIO_OUT);
+}
+
+void ledUpdate(void)
+{
+    // A latched fault owns both LEDs, so card traffic cannot paint over it.
+    if (sFaulted)
+    {
+        return;
+    }
+
+    uint32_t reads = gLedSdReadEvents;
+    uint32_t writes = gLedSdWriteEvents;
+    if (writes != sSeenWriteEvents)
+    {
+        sSeenWriteEvents = writes;
+        sWriteHold = LED_WRITE_HOLD_PASSES;
+    }
+    if (reads != sSeenReadEvents)
+    {
+        sSeenReadEvents = reads;
+        sReadHold = LED_READ_HOLD_PASSES;
+    }
+
+    sPass++;
+    bool dimTick = (sPass & ((1u << LED_READ_DUTY_SHIFT) - 1u)) == 0u;
+    gpio_put(PIN_LED_B, sWriteHold != 0 || (sReadHold != 0 && dimTick));
+
+    if (sWriteHold != 0)
+    {
+        sWriteHold--;
+    }
+    if (sReadHold != 0)
+    {
+        sReadHold--;
+    }
+}
+
+void ledPrepareForSleep(void)
+{
+    if (sFaulted)
+    {
+        return;
+    }
+    gpio_put(PIN_LED_B, false);
+}
+
+void ledSignalError(void)
+{
+    if (sFaulted)
+    {
+        return;
+    }
+    sFaulted = true;
+    // Blue off first, or a fault taken while it was lit strands both on.
+    gpio_put(PIN_LED_B, false);
+    gpio_put(PIN_LED_R, true);
+}
+
+#endif // ENABLE_STATUS_LEDS

--- a/src/led.h
+++ b/src/led.h
@@ -1,0 +1,47 @@
+#pragma once
+#include <stdint.h>
+
+#ifdef ENABLE_STATUS_LEDS
+
+// Bumped from SdCard::StateReadBegin and StateWriteBegin, which every transfer
+// passes through, the r4 and FatFs ones included. Counting there rather than in
+// the TryBegin* header inlines keeps this out of the __scratch_y card handlers,
+// which core 0's stack grows down into. A lost increment costs at most one
+// missed blink, so the plain ++ is enough.
+extern volatile uint32_t gLedSdReadEvents;
+extern volatile uint32_t gLedSdWriteEvents;
+
+/// @brief Records that the card state machine has taken up a read.
+static inline void ledNotifySdRead(void) { gLedSdReadEvents++; }
+
+/// @brief Records that the card state machine has taken up a write.
+static inline void ledNotifySdWrite(void) { gLedSdWriteEvents++; }
+
+/// @brief Claims the two LED pins and parks both dark.
+void ledInit(void);
+
+/// @brief Drives the blue LED from the counters above. Call once per main loop pass.
+void ledUpdate(void);
+
+/// @brief Clears the blue LED before the main loop sleeps. Has to run every pass,
+///        since the loop only wakes on an interrupt and a level left set stays set.
+void ledPrepareForSleep(void);
+
+/// @brief Latches red on and clears blue, to report an unrecoverable fault.
+///
+/// Out of line because it is called from __scratch_y handlers, where a static
+/// inline duplicated the store into each of them and grew the RAM resident time
+/// critical section.
+void ledSignalError(void);
+
+#else
+
+// With the flag off the call sites stay as they are and compile to nothing.
+static inline void ledNotifySdRead(void) { }
+static inline void ledNotifySdWrite(void) { }
+static inline void ledInit(void) { }
+static inline void ledUpdate(void) { }
+static inline void ledPrepareForSleep(void) { }
+static inline void ledSignalError(void) { }
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,7 @@
 #include "pico/bootrom.h"
 #include "hardware/xosc.h"
 #include "powerSaving.h"
+#include "led.h"
 
 static u32 sProgramOffset;
 FATFS sFatFs;
@@ -257,6 +258,8 @@ static inline void earlyGpioInit(void)
         usedPins >>= 1;
     }
 #endif
+
+    ledInit();
 }
 
 int __time_critical_func(main)()
@@ -268,6 +271,10 @@ int __time_critical_func(main)()
     bi_decl(bi_1pin_with_name(PIN_WREB, "Ntr card wreb (clock)"));
     bi_decl(bi_1pin_with_name(PIN_RST, "Ntr card reset"));
     bi_decl(bi_1pin_with_name(PIN_CS2, "Ntr card cs2 (spi enable)"));
+#ifdef ENABLE_STATUS_LEDS
+    bi_decl(bi_1pin_with_name(PIN_LED_R, "Status led red (fault)"));
+    bi_decl(bi_1pin_with_name(PIN_LED_B, "Status led blue (sd activity)"));
+#endif
 
     // u64 bootTime = time_us_64();
 
@@ -360,13 +367,20 @@ int __time_critical_func(main)()
 
     pwr_initPowerSaving();
 
+    // The blue LED runs off counters that SdCard bumps when a transfer starts,
+    // not off the card state sampled here: an r4 rom read or a FatFs write both
+    // begin and finish inside one pass, so a sample here would never see them.
     while (1)
     {
+        ledUpdate();
+
         gSdCard.Update();
         gSdCard.Update();
     #ifdef ENABLE_R4_MODE
         ntrc_gameR4Update();
     #endif
+
+        ledPrepareForSleep();
         __wfi();
     }
 }

--- a/src/ntrCardRomGameSd.cpp
+++ b/src/ntrCardRomGameSd.cpp
@@ -1,4 +1,5 @@
 #include "common.h"
+#include "led.h"
 #include <stdio.h>
 #include "r4.h"
 #include "ntrCardRom.h"
@@ -27,6 +28,7 @@ extern "C" void __scratch_y("cpu0") ntrc_gameReqSdReadCmd1(ntr_rom_emu_t* romEmu
         sBufferIndex = 0;
         if (!gSdCard.TryBeginReadSectors(&sSdSectorBuf[0], sReadSector, 1))
         {
+            ledSignalError();
             __breakpoint();
         }
         sReadBusy = true;
@@ -72,6 +74,7 @@ extern "C" void __scratch_y("cpu0") ntrc_gameGetSdStatCmd0(ntr_rom_emu_t* romEmu
     {
         if (!gSdCard.TryBeginWriteSectors(&sSdSectorBuf[sBufferIndex * 512], sNextWriteSector, 1, !sNextWriteIsLast))
         {
+            ledSignalError();
             __breakpoint();
         }
 
@@ -95,6 +98,7 @@ extern "C" void __scratch_y("cpu0") ntrc_gameGetSdDataCmd0(ntr_rom_emu_t* romEmu
     {
         if (!gSdCard.TryBeginReadSectors(&sSdSectorBuf[sBufferIndex * 512], sReadSector, 1))
         {
+            ledSignalError();
             __breakpoint();
         }
         sReadBusy = true;
@@ -133,6 +137,7 @@ static void __scratch_y("cpu0") sdWritePayloadComplete(ntr_rom_emu_t* romEmu)
     {
         if (!gSdCard.TryBeginWriteSectors(sSdSectorBuf, romEmu->cmd1, 1, !isLast))
         {
+            ledSignalError();
             __breakpoint();
         }
         sWriteBusy = true;
@@ -187,6 +192,7 @@ extern "C" void __scratch_y("cpu0") ntrc_gameR4StartSdReadCmd0(ntr_rom_emu_t* ro
         {
             if (!gSdCard.TryBeginReadSectors(sSdSectorBuf, sector, 1))
             {
+                ledSignalError();
                 __breakpoint();
             }
             sCurSdSector = sector;
@@ -221,6 +227,7 @@ static void __scratch_y("cpu0") r4SdWritePayloadComplete(ntr_rom_emu_t* romEmu)
 {
     if (__builtin_expect(!gSdCard.TryBeginWriteSectors(sSdSectorBuf, (romEmu->cmd0 << 8) >> 9, 1, false), false))
     {
+        ledSignalError();
         __breakpoint();
     }
 }

--- a/src/sd/SdCard.cpp
+++ b/src/sd/SdCard.cpp
@@ -1,4 +1,5 @@
 #include "../common.h"
+#include "../led.h"
 #include "pico/multicore.h"
 #include "hardware/clocks.h"
 #include "rp2040_sdio.h"
@@ -268,6 +269,10 @@ void SdCard::Update()
 
 void SdCard::StateReadBegin()
 {
+    // Every read reaches this state, the r4 and FatFs ones included, so this is
+    // the one place that sees all of them.
+    ledNotifySdRead();
+
     u32 sectorsLeft = _sectorCount - _sectorsCompleted;
     u32 startSector = _sectorAddress + _sectorsCompleted;
     if (startSector > _lastSdSector)
@@ -393,6 +398,8 @@ void SdCard::StateReadWriteCancel()
 
 void SdCard::StateWriteBegin()
 {
+    ledNotifySdWrite();
+
     _writeOffset = _sectorsCompleted;
     u32 sectorsLeft = _sectorCount - _sectorsCompleted;
     u32 startSector = _sectorAddress + _sectorsCompleted;


### PR DESCRIPTION
The board has two status leds that the firmware leaves dark. This adds the option to use
them, for anyone who wants that: blue blinks with SD card activity, and red stays on when
the firmware cannot start an SD transfer it needs, which are the six places that already
call __breakpoint() and freeze with no visible sign. A CPU hardfault or a card that stops
answering still fails silent, same as before.

It is off by default, behind ENABLE_STATUS_LEDS, because lighting the leds draws from the
DS battery. I followed the DSPICO_ENABLE_WRFUXXED pattern, so with the define commented out
nothing gets compiled in and every section of the build comes out the same size as develop.
With it on it adds 592 bytes of flash and 140 bytes of RAM, and the SD counting is done in
SdCard's state machine, not in the card interrupt handlers, to keep it out of scratch_y.

Tested on my DSpico with the define on and off, playing and saving a retail game.